### PR TITLE
Fix bugs in file logging

### DIFF
--- a/Vaiona.Logging/Loggers/FileLogger.cs
+++ b/Vaiona.Logging/Loggers/FileLogger.cs
@@ -41,27 +41,21 @@ namespace Vaiona.Logging.Loggers
         // This mechanism must be replaced with a robust solution. It is only experimental.
         public void LogCustom(string message)
         {
-            FileStream stream = null;
-            StreamWriter streamWriter = null;
+            // get file name
+            string logFile = buildLogFileName();
+
+            // prepare message
+            string wrappedMessage = string.Format("{0}: {1}", DateTime.UtcNow, message);
+
+            // append to file
             try
             {
-                string logFile = buildLogFileName();
-                stream = new FileStream(logFile, FileMode.Append, FileAccess.Write);
-                streamWriter = new StreamWriter((Stream)stream);
-                string wrappedMessage = string.Format("{0}: {1}", DateTime.UtcNow, message);
-                streamWriter.WriteLine(wrappedMessage);
-                
+                using (StreamWriter file = new StreamWriter(logFile, true))
+                {
+                    file.WriteLine(wrappedMessage);
+                }
             }
             catch { }
-            finally
-            {
-                try
-                {
-                    stream.Close();
-                    streamWriter.Close();
-                }
-                catch { }
-            }
         }
 
         public void LogData(DataLogEntry logEntry)

--- a/Vaiona.Logging/Loggers/FileLogger.cs
+++ b/Vaiona.Logging/Loggers/FileLogger.cs
@@ -23,7 +23,7 @@ namespace Vaiona.Logging.Loggers
 
         private string buildLogFileName()
         {
-            string serialNo = string.Format("{0}.{1}.{2}", DateTime.UtcNow.Day, DateTime.UtcNow.Month, DateTime.UtcNow.Year);
+            string serialNo = string.Format("{0}.{1}.{2}", DateTime.UtcNow.Year.ToString("D4"), DateTime.UtcNow.Month.ToString("D2"), DateTime.UtcNow.Day.ToString("D2") );
             string fileName = "bexis." + serialNo + ".log";
             string logFolder = Path.Combine(AppConfiguration.WorkspaceGeneralRoot, "Logging");
             if(!Directory.Exists(logFolder))


### PR DESCRIPTION
there were exceptions thrown when logging to a file

fixed that and adjusted the file name generation, so file are sorted naturally by date